### PR TITLE
Fix ph and orp mean values.

### DIFF
--- a/packages/raspipool/fc.yaml
+++ b/packages/raspipool/fc.yaml
@@ -3,7 +3,7 @@ sensor:
   - platform: template
     sensors:
       e_fc:
-        value_template: "{{ ( 0.23 * (1 + states('input_number.e_fc_adjust')|float / 100 ) * ( 14 - states('sensor.ph_mean')|float) ** ( 1 / (400 - states('sensor.orp_mean')|float) ) * ( states('sensor.ph_mean')|float -4.1) ** ( ( states('sensor.orp_mean')|float - 516)/145) + 10.0 ** ( (states('sensor.orp_mean')|float + states('sensor.ph_mean')|float * 70 -1282) / 40 ) ) |round(1) }}"
+        value_template: "{{ ( 0.23 * (1 + states('input_number.e_fc_adjust')|float / 100 ) * ( 14 - states('sensor.ph')|float) ** ( 1 / (400 - states('sensor.orp')|float) ) * ( states('sensor.ph')|float -4.1) ** ( ( states('sensor.orp')|float - 516)/145) + 10.0 ** ( (states('sensor.orp')|float + states('sensor.ph')|float * 70 -1282) / 40 ) ) |round(1) }}"
         unit_of_measurement: ppm
         # icon_template: mdi:chemical-weapon
         icon_template: mdi:react

--- a/packages/raspipool/muriatic.yaml
+++ b/packages/raspipool/muriatic.yaml
@@ -114,7 +114,7 @@ automation:
   - service: input_number.set_value
     data_template:
       entity_id: input_number.muriatic_inject
-      value: " {{ ( states('input_number.capacity')|float * ( 10 ** (8 - states('input_number.ph_target')|float ) - 10 ** (8 - states('sensor.ph_mean')|float ) ) * (126.19 / states('input_number.muriatic_concentration')|float ),0 )|max |round(0)|int }} "
+      value: " {{ ( states('input_number.capacity')|float * ( 10 ** (8 - states('input_number.ph_target')|float ) - 10 ** (8 - states('sensor.ph')|float ) ) * (126.19 / states('input_number.muriatic_concentration')|float ),0 )|max |round(0)|int }} "
 
 - alias: muriatic_inject
   id: '1559949826459'

--- a/packages/raspipool/orp.yaml
+++ b/packages/raspipool/orp.yaml
@@ -12,7 +12,7 @@ sensor:
 # For I2C enter the hex device id
     port: 0x62
 #    offset: 78
-    scan_interval: 300
+    scan_interval: 10
 
 automation:
 - alias: orp_start
@@ -35,12 +35,12 @@ automation:
   initial_state: true
   trigger:
   - platform: template
-    value_template: '{{state_attr("sensor.orp_mean", "standard_deviation") > 20 }}'
+    value_template: '{{state_attr("sensor.orp", "standard_deviation") > 20 }}'
   condition: []
   action:
   - service: notify.pushbullet
     data_template:
-      message: 'Between {{state_attr("sensor.orp_mean", "min_value")}} and {{state_attr("sensor.orp_mean", "max_value")}}{{- "\n\n" -}}@{{now().strftime("%H:%M")}}[{{now().day}}/{{now().month}}]'
+      message: 'Between {{state_attr("sensor.orp", "min_value")}} and {{state_attr("sensor.orp", "max_value")}}{{- "\n\n" -}}@{{now().strftime("%H:%M")}}[{{now().day}}/{{now().month}}]'
       title: 'ORP probe bad (calibrate?) !!!'
   - service: automation.turn_off
     entity_id: automation.orp_bad

--- a/packages/raspipool/ph.yaml
+++ b/packages/raspipool/ph.yaml
@@ -4,7 +4,7 @@ sensor:
 #   port: /dev/ttyUSB0
 # For I2C enter the hex device id
     port: 0x63
-    scan_interval: 300
+    scan_interval: 10
 
   - platform: statistics
     name: ph
@@ -43,7 +43,7 @@ automation:
   initial_state: true
   trigger:
   - platform: numeric_state
-    entity_id: sensor.ph_mean
+    entity_id: sensor.ph
     above: 7.5
     for:
       hours: 48
@@ -60,7 +60,7 @@ automation:
   initial_state: true
   trigger:
   - platform: numeric_state
-    entity_id: sensor.ph_mean
+    entity_id: sensor.ph
     below: 6.9
     for:
       hours: 48
@@ -77,7 +77,7 @@ automation:
   initial_state: true
   trigger:
   - platform: template
-    value_template: '{{state_attr("sensor.ph_mean", "standard_deviation") > 0.1}}'
+    value_template: '{{state_attr("sensor.ph", "standard_deviation") > 0.1}}'
   condition: []
   action:
   - service: notify.pushbullet

--- a/packages/raspipool/recorder.yaml
+++ b/packages/raspipool/recorder.yaml
@@ -5,8 +5,8 @@ recorder:
     entities:
       - sensor.pump_state
       - sensor.pool_temp_mean
-      - sensor.orp_mean
-      - sensor.ph_mean
+      - sensor.orp
+      - sensor.ph
       - sensor.pool_water_temperature
       - sensor.ezo_ph
       - sensor.ezo_orp

--- a/packages/raspipool/temp.yaml
+++ b/packages/raspipool/temp.yaml
@@ -1,32 +1,31 @@
 sensor:
-#  - platform: template
-#    sensors:
-#      pool_temp:
-#        friendly_name: "Pool Temp."
-#        entity_id: sensor.pool_water_temperature
-#        value_template: "{{ states('sensor.pool_water_temperature')|float|round(1) }}"
-#        # icon_template: mdi:coolant-temperature
-#        icon_template: mdi:oil-temperature
-#        unit_of_measurement: 'ºC'
-#  - platform: onewire
-#    names:
-#      28-011564d449ff: Pool water
-#      28-031504ae5eff: Pool water
-#    scan_interval: 31536000
+  - platform: template
+    sensors:
+      pool_temp:
+        friendly_name: "water temperature"
+        entity_id: sensor.pool_water_temperature
+        value_template: "{{ states('sensor.pool_water_temperature')|float|round(1) }}"
+        icon_template: mdi:coolant-temperature
+        # icon_template: mdi:oil-temperature
+        unit_of_measurement: 'ºC'
+  - platform: onewire
+    names:
+      28-0319a2792bc3: Pool water
+    scan_interval: 10
 
 # Atlas Resistance Temperature Detector (RTD)
-  - platform: atlas_scientific
+#  - platform: atlas_scientific
 # For serial ports use:
 #   port: /dev/ttyUSB0
 # For I2C enter the hex device id
-    port: 0x66
-    scan_interval: 300
+#    port: 0x66
+#    scan_interval: 300
 
-  - platform: statistics
-    name: pool_water_temperature
-    entity_id: sensor.ezo_temperature
-    max_age:
-      minutes: 60
+#  - platform: statistics
+#    name: pool_water_temperature
+#    entity_id: sensor.ezo_temperature
+#    max_age:
+#      minutes: 60
 
 automation:
 - alias: temp_lo

--- a/ui-lovelace.yaml
+++ b/ui-lovelace.yaml
@@ -26,7 +26,7 @@ views:
               - max: 8
                 min: 6.5
                 theme: Backend-selected
-                entity: sensor.ph_mean
+                entity: sensor.ph
                 severity:
                   green: 6.95
                   red: 7.75
@@ -36,7 +36,7 @@ views:
               - max: 1999
                 min: -1999
                 theme: Backend-selected
-                entity: sensor.orp_mean
+                entity: sensor.orp
                 severity:
                   green: 650
                   red: 800
@@ -139,9 +139,9 @@ views:
                 name: Bleach inj.
               - entity: switch.ph
                 name: Muriatic inj.
-              - entity: sensor.ph_mean
+              - entity: sensor.ph
                 name: pH
-              - entity: sensor.orp_mean
+              - entity: sensor.orp
                 name: ORP
               - entity: sensor.pool_water_temperature
                 name: water temp.
@@ -154,9 +154,9 @@ views:
                 name: Bleach inj.
               - entity: switch.ph
                 name: Muriatic inj.
-              - entity: sensor.ph_mean
+              - entity: sensor.ph
                 name: pH
-              - entity: sensor.orp_mean
+              - entity: sensor.orp
                 name: ORP
               - entity: sensor.pool_water_temperature
                 name: water temp.
@@ -257,7 +257,7 @@ views:
             type: section
           - entity: input_number.ph_target
             name: pH target
-          - entity: sensor.ph_mean
+          - entity: sensor.ph
             name: pH actual
           - entity: input_number.muriatic_inject
             name: Next muriatic injection (ml)


### PR DESCRIPTION
It seems that mean does not work (anymore?). The default value is
the mean value, so simply putting ph and orp does seem to work.

Also, these I believe were wrong anyway:
ph.yaml:
value_template:
'{{state_attr("sensor.ph", "standard_deviation") > 0.1}}'

orp.yaml:
value_template:
'{{state_attr("sensor.orp", "standard_deviation") > 20 }}'